### PR TITLE
fix: arm builds, regions and logging

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           echo "GORELEASER_ARGS=--snapshot --skip publish --skip sign" >> $GITHUB_ENV
       - name: setup-quill
-        uses: 1password/load-secrets-action@v1
+        uses: 1password/load-secrets-action@v2
         # Extra Safeguard - This ensures the secrets are only loaded on tag and a tag that the repo owner triggered
         if: startsWith(github.ref, 'refs/tags/') == true && github.actor == github.repository_owner
         with:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,10 +13,10 @@ builds:
       - windows
     goarch:
       - amd64
-      - arm64
-      - arm
-    goarm:
-      - "7"
+    #  - arm64
+    #  - arm
+    #goarm:
+    #  - "7"
     ignore:
       - goos: windows
         goarch: arm64
@@ -66,47 +66,48 @@ dockers:
       - "--label=org.opencontainers.image.version={{.Version}}"
       - "--label=org.opencontainers.image.source=https://github.com/ekristen/azure-nuke"
       - "--platform=linux/amd64"
-  - use: buildx
-    goos: linux
-    goarch: arm64
-    dockerfile: Dockerfile
-    image_templates:
-      - ghcr.io/ekristen/azure-nuke:v{{ .Version }}-arm64
-    build_flag_templates:
-      - "--target=goreleaser"
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://github.com/ekristen/azure-nuke"
-      - "--platform=linux/arm64"
-  - use: buildx
-    goos: linux
-    goarch: arm
-    goarm: "7"
-    dockerfile: Dockerfile
-    image_templates:
-      - ghcr.io/ekristen/azure-nuke:v{{ .Version }}-arm32v7
-    build_flag_templates:
-      - "--target=goreleaser"
-      - "--pull"
-      - "--label=org.opencontainers.image.created={{.Date}}"
-      - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
-      - "--label=org.opencontainers.image.source=https://github.com/ekristen/azure-nuke"
-      - "--platform=linux/arm/v7"
+  #- use: buildx
+  #  goos: linux
+  #  goarch: arm64
+  #  dockerfile: Dockerfile
+  #  image_templates:
+  #    - ghcr.io/ekristen/azure-nuke:v{{ .Version }}-arm64
+  #  build_flag_templates:
+  #    - "--target=goreleaser"
+  #    - "--pull"
+  #    - "--label=org.opencontainers.image.created={{.Date}}"
+  #    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+  #    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  #    - "--label=org.opencontainers.image.version={{.Version}}"
+  #    - "--label=org.opencontainers.image.source=https://github.com/ekristen/azure-nuke"
+  #    - "--platform=linux/arm64"
+  #- use: buildx
+  #  goos: linux
+  #  goarch: arm
+  #  goarm: "7"
+  #  dockerfile: Dockerfile
+  #  image_templates:
+  #    - ghcr.io/ekristen/azure-nuke:v{{ .Version }}-arm32v7
+  #  build_flag_templates:
+  #    - "--target=goreleaser"
+  #    - "--pull"
+  #    - "--label=org.opencontainers.image.created={{.Date}}"
+  #    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+  #    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  #    - "--label=org.opencontainers.image.version={{.Version}}"
+  #    - "--label=org.opencontainers.image.source=https://github.com/ekristen/azure-nuke"
+  #    - "--platform=linux/arm/v7"
 docker_manifests:
   - use: docker
     name_template: ghcr.io/ekristen/azure-nuke:v{{ .Version }}
     image_templates:
       - ghcr.io/ekristen/azure-nuke:v{{ .Version }}-amd64
-      - ghcr.io/ekristen/azure-nuke:v{{ .Version }}-arm64
-      - ghcr.io/ekristen/azure-nuke:v{{ .Version }}-arm32v7
+  #    - ghcr.io/ekristen/azure-nuke:v{{ .Version }}-arm64
+  #    - ghcr.io/ekristen/azure-nuke:v{{ .Version }}-arm32v7
 signs:
   - ids:
       - default
+      - darwin
     cmd: cosign
     signature: "${artifact}.sig"
     certificate: "${artifact}.pem"

--- a/pkg/azure/tenant.go
+++ b/pkg/azure/tenant.go
@@ -59,25 +59,25 @@ func NewTenant( //nolint:gocyclo
 	client := subscription.NewSubscriptionsClient()
 	client.Authorizer = authorizers.Management
 
-	logrus.Trace("listing subscriptions")
+	log.Trace("listing subscriptions")
 	for list, err := client.List(ctx); list.NotDone(); err = list.NextWithContext(ctx) {
 		if err != nil {
 			return nil, err
 		}
 		for _, s := range list.Values() {
 			if len(subscriptionIDs) > 0 && !slices.Contains(subscriptionIDs, *s.SubscriptionID) {
-				logrus.Warnf("skipping subscription id: %s (reason: not requested)", *s.SubscriptionID)
+				log.Warnf("skipping subscription id: %s (reason: not requested)", *s.SubscriptionID)
 				continue
 			}
 
-			logrus.Tracef("adding subscriptions id: %s", *s.SubscriptionID)
+			log.Tracef("adding subscriptions id: %s", *s.SubscriptionID)
 			tenant.SubscriptionIds = append(tenant.SubscriptionIds, *s.SubscriptionID)
 
-			logrus.Trace("listing resource groups")
+			log.Trace("listing resource groups")
 			groupsClient := resources.NewGroupsClient(*s.SubscriptionID)
 			groupsClient.Authorizer = authorizers.Management
 
-			logrus.Debugf("configured regions: %v", regions)
+			log.Debugf("configured regions: %v", regions)
 			for list, err := groupsClient.List(ctx, "", nil); list.NotDone(); err = list.NextWithContext(ctx) {
 				if err != nil {
 					return nil, err
@@ -89,7 +89,7 @@ func NewTenant( //nolint:gocyclo
 						continue
 					}
 
-					logrus.Debugf("resource group name: %s", *g.Name)
+					log.Debugf("resource group name: %s", *g.Name)
 					tenant.ResourceGroups[*s.SubscriptionID] = append(tenant.ResourceGroups[*s.SubscriptionID], *g.Name)
 				}
 			}

--- a/pkg/commands/nuke/command.go
+++ b/pkg/commands/nuke/command.go
@@ -94,11 +94,13 @@ func execute(c *cli.Context) error { //nolint:funlen
 	}
 	if !slices.Contains(parsedConfig.Regions, "all") {
 		filters[filter.Global] = append(filters[filter.Global], filter.Filter{
-			Property: "Location",
+			Property: "Region",
 			Type:     filter.NotIn,
 			Values:   parsedConfig.Regions,
 		})
 	}
+
+	fmt.Println(filters[filter.Global])
 
 	n := libnuke.New(params, filters, parsedConfig.Settings)
 

--- a/resources/security-alert.go
+++ b/resources/security-alert.go
@@ -35,7 +35,7 @@ type SecurityAlert struct {
 	id          string
 	name        string
 	displayName string
-	location    string
+	region      string
 	status      string
 }
 
@@ -50,7 +50,7 @@ func (r *SecurityAlert) Filter() error {
 func (r *SecurityAlert) Remove(ctx context.Context) error {
 	// Note: we cannot actually remove alerts :(
 	// So we just have to dismiss them instead
-	_, err := r.client.UpdateSubscriptionLevelStateToDismiss(ctx, r.location, r.name)
+	_, err := r.client.UpdateSubscriptionLevelStateToDismiss(ctx, r.region, r.name)
 	return err
 }
 
@@ -59,7 +59,7 @@ func (r *SecurityAlert) Properties() types.Properties {
 
 	properties.Set("Name", r.name)
 	properties.Set("DisplayName", r.displayName)
-	properties.Set("Location", r.location)
+	properties.Set("Region", r.region)
 	properties.Set("Status", r.status)
 
 	return properties
@@ -108,7 +108,7 @@ func (l SecurityAlertsLister) List(ctx context.Context, o interface{}) ([]resour
 				id:          *g.ID,
 				name:        *g.Name,
 				displayName: ptr.ToString(g.AlertDisplayName),
-				location:    matches[1],
+				region:      matches[1],
 				status:      string(g.AlertProperties.Status),
 			})
 		}

--- a/resources/ssh-key.go
+++ b/resources/ssh-key.go
@@ -28,7 +28,7 @@ func init() {
 type SSHPublicKey struct {
 	client         compute.SSHPublicKeysClient
 	rg             *string
-	location       *string
+	region         *string
 	name           *string
 	subscriptionID *string
 	tags           map[string]*string
@@ -43,7 +43,7 @@ func (r *SSHPublicKey) Properties() types.Properties {
 	properties := types.NewProperties()
 
 	properties.Set("Name", r.name)
-	properties.Set("Location", r.location)
+	properties.Set("Region", r.region)
 	properties.Set("ResourceGroup", r.rg)
 	properties.Set("SubscriptionID", r.subscriptionID)
 
@@ -88,11 +88,11 @@ func (l SSHPublicKeyLister) List(ctx context.Context, o interface{}) ([]resource
 		log.Trace("list not done")
 		for _, g := range list.Values() {
 			resources = append(resources, &SSHPublicKey{
-				client:   client,
-				name:     g.Name,
-				rg:       nuke.GetResourceGroupFromID(*g.ID),
-				location: g.Location,
-				tags:     g.Tags,
+				client: client,
+				name:   g.Name,
+				rg:     nuke.GetResourceGroupFromID(*g.ID),
+				region: g.Location,
+				tags:   g.Tags,
 			})
 		}
 


### PR DESCRIPTION
This disables ARM builds again, it seems that for some reason with all the azure dependencies the build is exceeding CPU/Memory for open source builds. Will have to look at other options.

This fixes an oversight with the renaming of Locations to Regions as well.

Resolves #54 