### PR TITLE
Add ManagedCluster to the managed resources

### DIFF
--- a/resources/managed-cluster.go
+++ b/resources/managed-cluster.go
@@ -1,0 +1,101 @@
+package resources
+
+import (
+	"context"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2022-07-01/containerservice"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/ekristen/libnuke/pkg/registry"
+	"github.com/ekristen/libnuke/pkg/resource"
+	"github.com/ekristen/libnuke/pkg/types"
+
+	"github.com/ekristen/azure-nuke/pkg/azure"
+)
+
+const ManagedClusterResource = "ManagedCluster"
+
+func init() {
+	registry.Register(&registry.Registration{
+		Name:     ManagedClusterResource,
+		Scope:    azure.ResourceGroupScope,
+		Resource: &ManagedCluster{},
+		Lister:   &ManagedClusterLister{},
+	})
+}
+
+type ManagedCluster struct {
+	*BaseResource `property:",inline"`
+
+	client containerservice.ManagedClustersClient
+	ID     *string
+	Name   *string
+	Tags   map[string]*string
+}
+
+func (r *ManagedCluster) Remove(ctx context.Context) error {
+	_, err := r.client.Delete(ctx, *r.ResourceGroup, *r.Name)
+	return err
+}
+
+func (r *ManagedCluster) Properties() types.Properties {
+	return types.NewPropertiesFromStruct(r)
+}
+
+func (r *ManagedCluster) String() string {
+	return *r.Name
+}
+
+// -----------------------------------------
+
+type ManagedClusterLister struct {
+}
+
+func (l ManagedClusterLister) List(ctx context.Context, o interface{}) ([]resource.Resource, error) {
+	opts := o.(*azure.ListerOpts)
+
+	log := logrus.WithField("r", ManagedClusterResource).WithField("s", opts.SubscriptionID)
+
+	client := containerservice.NewManagedClustersClient(opts.SubscriptionID)
+	client.Authorizer = opts.Authorizers.Management
+	client.RetryAttempts = 1
+	client.RetryDuration = time.Second * 2
+
+	resources := make([]resource.Resource, 0)
+
+	log.Trace("attempting to list managed clusters")
+
+	list, err := client.ListByResourceGroup(ctx, opts.ResourceGroup)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Trace("listing resources")
+
+	for list.NotDone() {
+		log.Trace("list not done")
+		for _, g := range list.Values() {
+			resources = append(resources, &ManagedCluster{
+				BaseResource: &BaseResource{
+					Region:         g.Location,
+					ResourceGroup:  &opts.ResourceGroup,
+					SubscriptionID: &opts.SubscriptionID,
+				},
+				client: client,
+				ID:     g.ID,
+				Name:   g.Name,
+				Tags:   g.Tags,
+			})
+
+		}
+
+		if err := list.NextWithContext(ctx); err != nil {
+			return nil, err
+		}
+	}
+
+	log.Trace("done")
+
+	return resources, nil
+}


### PR DESCRIPTION
Closes https://github.com/ekristen/azure-nuke/issues/82

I'm not sure if there are some unit tests I can add, let me know if that's the case. 

I tested it with my Azure account (I removed some of the info): 

```
../azure-nuke/bin/azure-nuke run --config clean.yaml --force --prompt-delay 3 --no-dry-run
> azure-nuke - 1.0.0-dev - dirty
Do you really want to nuke the tenant and subscriptions with the ID SUBSCRIPTION_ID?
Waiting 3s before continuing.
westus2 - ManagedCluster - testnuke - [ID: "", Name: "testnuke", Region: "westus2", ResourceGroup: "group", SubscriptionID: "SUBSCRIPTION_ID", tag:XXXX] - would remove
Scan complete: 1 total, 1 nukeable, 0 filtered.

Do you really want to nuke the tenant and subscriptions with the ID cc0b82f3-7c2e-400b-aec3-40a3d720505b?
Waiting 3s before continuing.
westus2 - ManagedCluster - testnuke - [ID: "", Name: "testnuke", Region: "westus2", ResourceGroup: "group", SubscriptionID: "SUBSCRIPTION_ID", tag:XXXX] - triggered remove

Removal requested: 1 waiting, 0 failed, 0 skipped, 0 finished

westus2 - ManagedCluster - florent-clarret-testnuke-aks - [ID: "", Name: "testnuke", Region: "westus2", ResourceGroup: "group", SubscriptionID: "westus2", tag:XXXX] - waiting

...

westus2 - ManagedCluster - testnuke - [ID: "", Name: "testnuke", Region: "westus2", ResourceGroup: "group", SubscriptionID: "SUBSCRIPTION_ID", tag:XXXX] - removed

Removal requested: 0 waiting, 0 failed, 0 skipped, 1 finished

Nuke complete: 0 failed, 0 skipped, 1 finished.
```

It took 4 minutes 11 here.

Side note: I wanted to map `g.SystemData.CreatedAt` to the struct but it appears to be nil